### PR TITLE
Fix bug, missed a line from 'xresources' patch.

### DIFF
--- a/config.def.h
+++ b/config.def.h
@@ -59,6 +59,7 @@ static const Layout layouts[] = {
 #define SHCMD(cmd) { .v = (const char*[]){ "/bin/sh", "-c", cmd, NULL } }
 
 /* commands */
+static char dmenumon[2] = "0"; /* component of dmenucmd, manipulated in spawn() */
 static const char *dmenucmd[] = { "dmenu_run", "-m", dmenumon, "-fn", dmenufont, "-nb", normbgcolor, "-nf", normfgcolor, "-sb", selbordercolor, "-sf", selfgcolor, NULL };
 static const char *termcmd[]  = { "st", NULL };
 


### PR DESCRIPTION
Missing a line from `xresources` patch cause failure in building and installing package.
this commit will fix that.